### PR TITLE
Update ete4 to 4.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ete4" %}
-{% set version = "4.3.0" %}
+{% set version = "4.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/ete4-{{ version }}.tar.gz
-  sha256: c063588a9c77aa16a3de93de4d2016afae0236d4daf325d6290ed668d15a4b86
+  sha256: 0306ab66c2a1685946f94a4912718a5812dfc3059070300fc25d0e2b881bb8d1
 
 build:
   skip: true  # [py<37 or win]
   entry_points:
     - ete4 = ete4.tools.ete:main
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   build:
@@ -31,6 +31,7 @@ requirements:
   run:
     - python
     - bottle
+    - cheroot
     - brotli
     - numpy
     - scipy
@@ -48,7 +49,7 @@ test:
 about:
   home: https://etetoolkit.org
   summary: A Python Environment for (phylogenetic) Tree Exploration
-  license: GPL-3.0-only
+  license: GPL-3.0-or-later
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
Updates ETE4 from 4.3.0 to 4.4.0.

- resets the build number
- adds the newly declared cheroot runtime dependency
- aligns the recipe license expression with the 4.4.0 package metadata

Local validation:
- conda-smithy recipe-lint recipe --conda-forge
- conda-build for osx-64 / Python 3.10
- packaged tests: pip check, import ete4, and ete4 --help